### PR TITLE
Add Code of Conduct to Guide

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of Conduct
+
+All contributors and maintainers of this guide, in the interest of fostering an open and welcoming community, are required to adhere to the [Major League Hacking Code of Conduct][mlh-coc].
+
+### Addendum for Open Source Projects
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to the [Major League Hacking Code of Conduct][mlh-coc], or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the [Code of Conduct][mlh-coc] may be permanently removed from the project team.
+
+The [Major League Hacking Code of Conduct][mlh-coc] applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+### Credits
+
+Inspired by [Jekyll's Code of Conduct][jekyll-coc].
+
+[mlh-coc]: https://github.com/MLH/mlh-policies/blob/master/code-of-conduct.md
+[jekyll-coc]: https://github.com/jekyll/jekyll/blob/master/CONDUCT.markdown

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # The MLH Hackathon Organizer Guide
 
-Welcome to the MLH Hackathon Organizer Guide! This is a community initiative by [Major League Hacking](http://mlh.io) that contains a lot of the lessons that we and the hackathon community around the world have learnt from organizing hackathons &mdash; all in a single student hackathon playbook.
+Welcome to the MLH Hackathon Organizer Guide! This is a community initiative by [Major League Hacking][mlh] that contains a lot of the lessons that we and the hackathon community around the world have learnt from organizing hackathons &mdash; all in a single student hackathon playbook.
 
 Take a look and learn some of the practices used by hackathon organizers all around the world. This guide should contain most, if not all, of the practices you need to throw a great hackathon.
 
-**Disclaimer:** The hackathon organizer guide is never finished. It's an ongoing project that we're always trying to update as we and the global hackathon organizer community learn. Try everything, contribute your learnings back to the guide with a pull request over on [our GitHub repository for this guide](http://github.com/mlh/hackathon-organizer-guide).
+**Disclaimer:** The hackathon organizer guide is never finished. It's an ongoing project that we're always trying to update as we and the global hackathon organizer community learn. Try everything, contribute your learnings back to the guide with a pull request over on [our GitHub repository for this guide][mlh-hackathon-organizer-guide].
 
 # Introduction to Organizer Guide
 
@@ -12,16 +12,29 @@ Take a look and learn some of the practices used by hackathon organizers all aro
 
 Are you ready to host your school’s very own hackathon?
 
-[Each semester, more than 50,000 developers, designers, and makers compete for their school's glory at the 150+ official MLH hackathons around the world.](https://mlh.io/about) Whether you’re hosting your first or third MLH hackathon, our organizer guide will give you the tools to blow away your student hacker community.
+[Each semester, more than 50,000 developers, designers, and makers compete for their school's glory at the 150+ official MLH hackathons around the world.][mlh-about] Whether you’re hosting your first or third MLH hackathon, our organizer guide will give you the tools to blow away your student hacker community.
 
-Major League Hacking's [mission is to empower hackers](https://mlh.io/about). This guide helps us support organizers in their pursuit to throw incredible hackathons and empower hackers to build great hacks.
+Major League Hacking's [mission is to empower hackers][mlh-about]. This guide helps us support organizers in their pursuit to throw incredible hackathons and empower hackers to build great hacks.
+
+#### Code of Conduct
+
+We enforce a Code of Conduct for all maintainers and contributors of this Guide. Read more in [CONDUCT.md][code-of-conduct].
 
 #### License
 
-The Hackathon Organizer Guide is open sourced under the [Creative Commons Attribution 4.0 International (CC-BY 4.0)](https://creativecommons.org/licenses/by/4.0/) license. [Read more here](LICENSE.md).
+The Hackathon Organizer Guide is open sourced under the [Creative Commons Attribution 4.0 International (CC-BY 4.0)][creative-commons] license. [Read more here][license].
 
 #### Resources
 
-* Article: [How to Throw an Epic Hackathon](http://news.mlh.io/how-to-throw-an-epic-hackathon-07-07-2014)
+- Article: [How to Throw an Epic Hackathon][how-to-throw-an-epic-hackathon]
 
-* MLH: [Official Slack channel](https://mlh.slack.com/)
+- MLH: [Official Slack channel][mlh-slack]
+
+[mlh]: https://mlh.io
+[mlh-about]: https://mlh.io/about
+[mlh-hackathon-organizer-guide]: (https://github.com/mlh/hackathon-organizer-guide)
+[mlh-slack]: https://mlh.slack.com
+[creative-commons]: https://creativecommons.org/licenses/by/4.0/
+[license]: LICENSE.md
+[code-of-conduct]: CONDUCT.md
+[how-to-throw-an-epic-hackathon]: http://news.mlh.io/how-to-throw-an-epic-hackathon-07-07-2014


### PR DESCRIPTION
Extends the Major League Hacking's [Code of Conduct](https://mlh.io/code-of-conduct) to the Guide (and eventually all of our open source projects). We've always assumed they were in place, but we're making it explicit to avoid any possible confusion.

Added an extension to consider who and what exactly it covers in an open source project setting. It is inspired by [Jekyll's Code of Conduct](https://github.com/jekyll/jekyll/blob/master/CONDUCT.markdown) which was inspired by Rails.