### PR TITLE
Add HackathonManager to Sofware for Hackathons page

### DIFF
--- a/Organizer-Resources/Software-for-Hackathons.md
+++ b/Organizer-Resources/Software-for-Hackathons.md
@@ -11,6 +11,7 @@ Student Hackathon Organizers have been building software to make manging their e
 ## Admissions 
 
 * [Nucleus](https://github.com/hacktx/nucleus) - An extensible and comprehensive hackathon application system that integrates with MyMLH, Slack and more from HackTX. Built using **PHP**. 
+* [HackathonManager](https://github.com/codeRIT/hackathon-manager) - An all-in-one platform for hackathon registration & logistics with support for MyMLH. Accept applications, facilitate RSVPs, coordinate busses, communicate with hackers, and more from a single tool. Built using **Ruby on Rails**  by the codeRIT team.
 
 ## Registration
 


### PR DESCRIPTION
[HackathonManager](https://github.com/codeRIT/hackathon-manager) is the tool we've been using for BrickHack for the past 5 years (and WiCHacks for the past two), and integrates with MyMLH.

It is now being made available as a self-service tool for any hackathon to use, and would make a great addition to this list!