### PR TITLE
Hardware Hackathon Organizing Guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -49,6 +49,7 @@
   * [Check-in Process](general-information/managing-registrations/check-in-process.md)
 * [Event Logistics](general-information/event-logistics/README.md)
   * [Hackathon Communication Platform](general-information/event-logistics/hackathon-communication-platform.md)
+  * [Hackathon Themes](general-information/event-logistics/hackathon-themes.md)
   * [Project Challenges](general-information/event-logistics/project-challenges.md)
   * [Ordering Swag and Prizes](general-information/event-logistics/ordering-swag-and-prizes.md)
   * [Set Up Your Event](general-information/event-logistics/set-up-your-event.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -79,6 +79,23 @@
   * [Closing Ceremony](general-information/day-of-logistics-and-hacker-experience/closing-ceremony.md)
 * [After the Event](general-information/after-the-event.md)
 
+
+## Hardware Hackathon Guide
+* [Introduction](hardware-hackathon-guide/INTRO.md)
+* [Why Hardware Hackathons](hardware-hackathon-guide/why-hardware-hackathons.md)
+* [Naming and Framing Your Event](hardware-hackathon-guide/naming-and-framing-your-event.md)
+* [Hardware Hackathon Organizing Timeline](hardware-hackathon-guide/hardware-hackathon-timeline.md)
+* [Recruitment](hardware-hackathon-guide/recruitment.md)
+* [Challenges](hardware-hackathon-guide/challenges.md)
+* [Pitfalls](hardware-hackathon-guide/pitfalls.md)
+* [Hardware Labs and Additional Resources](hardware-hackathon-guide/.hardware-labs-and-additional-resources.md)
+* [Workshops and Learning Resources](hardware-hackathon-guide/workshops-and-learning-resources.md)
+* [(Physical) Environment Requirements](hardware-hackathon-guide/environment-requirements.md)
+* [Prizes](hardware-hackathon-guide/prizes.md)
+* [Sponsors and Partners](hardware-hackathon-guide/sponsors-and-partners.md)
+* [After the Hack](hardware-hackathon-guide/after-the-hack.md)
+
+
 ## Organizer Resources
 
 * [Template Links](organizer-resources/template-links.md)

--- a/general-information/event-logistics/hackathon-themes.md
+++ b/general-information/event-logistics/hackathon-themes.md
@@ -1,0 +1,15 @@
+# Themes
+
+Hackathon themes are often broad and might help with decorations or goals of the event:
+
+### Social Impact Theme Ideas: 
+* Civic advocacy - addressing local community problems
+* Sustainability and Environmental Impacts - focusing on renewable energy, waste reduction, monitoring, or local sustainability efforts
+* https://sdgs.un.org/goals UN Sustainable Development Goals (SDGs) - poverty, quality education, climate action
+
+### Decoration Themes Ideas: 
+* Astronomy
+* Hack to the Future
+* Oceans, seas, and beaches
+* Wild West
+* Prom

--- a/hardware-hackathon-guide/INTRO.md
+++ b/hardware-hackathon-guide/INTRO.md
@@ -1,0 +1,2 @@
+# Introduction to the Hardware Hackathon Organizing Guide
+

--- a/hardware-hackathon-guide/after-the-hack.md
+++ b/hardware-hackathon-guide/after-the-hack.md
@@ -1,0 +1,36 @@
+# After the Hack
+
+Don't forget to see our [end of event check-list](../general-information/after-the-event.md) before you focus on hardware specific things here.
+
+### Connect Participants to Resources
+* Direct hackers to local campus makerspaces or fabrication lab.
+* Publicize relevant campus classes (e.g., in engineering, design, or applied arts) that build upon the skills used at the hackathon (e.g. repost course advertisements from volunteer faculty)
+* Highlight other local or national hardware-focused events, such as specialized buildathons or technical conferences.
+* Remind hackers to document their prototype, the story, and evidence of their build to support their personal portfolio for future jobs
+
+### Future Marketing
+Make sure to gather high-quality photos and videos of the working prototypes during judging. 
+
+### Lab Maintenance and Restock
+As part of the event wrap-up, run your end-of-event checklist for all hardware components and tools. Filter out broken or malfunctioning equipment and components (e.g., melted breadboards, shorted microcontrollers). Inventory all remaining functional equipment.
+Use the damage report and inventory list to inform the purchasing budget for the next event (i.e., you know exactly how many Arduinos you need to buy and replace).
+
+Finally, conduct a thorough cleanup of all borrowed spaces (makerspaces, classrooms). Follow the post-event checklist to ensure all tools are returned, supplies are put away, and the space is left in better condition than you found it to ensure the chance of relying on the space (or more) for future events.
+
+### Event Evaluation
+Evaluation should be based on your event's primary goals defined during initial planning. Develop an evaluation plan early to collect data leading up to and throughout the event weekend.
+
+#### Additional Data Sources to Consider
+| Area of Interest | Examples of Metrics |
+| :--- | :--- |
+| Learning | Workshop attendance and effectiveness ratings. |
+| Theme | Participant feedback on the theme's relevance and engagement level. |
+| Logistics | Feedback on component availability, variety, and lab accessibility. |
+| Mentors | Mentor helpfulness ratings and assessment of sufficient experience at stations. |
+
+
+Distribute a concise, goal-focused survey immediately after the event. Collect data from all roles (participants, volunteers, judges, mentors, organizers, sponsors), customizing questions where applicable.
+
+Document the number of total participants, diversity breakdown, and percentage of first-time hackers.
+
+Document checkout history, finalized component lists, and damage reports to note trends and inform future lab purchases.

--- a/hardware-hackathon-guide/challenges.md
+++ b/hardware-hackathon-guide/challenges.md
@@ -1,0 +1,11 @@
+# Challenges
+
+Challenges are optional or required tracks that include specific criteria or resources for eligibility. They help guide participants toward specific technologies or applications.
+
+### Hardware Challenge Examples
+* Wearable Tech - textiles, health monitoring
+* Assistive Devices - smart devices, accessible living, fall detection
+* IoT and Automation - smart automation
+* Efficient fabrication/design - minimal material use, compact housings
+* Using specialized hardware - integrating sponsored components, using new/recent hardware
+When defining challenges, encourage teams to use modular mounting solutions to keep components secure and organized. It may help improve the durability of a project, which is often tested when projects need to be moved for judging/expo. 

--- a/hardware-hackathon-guide/environment-requirements.md
+++ b/hardware-hackathon-guide/environment-requirements.md
@@ -1,0 +1,31 @@
+# (Physical) Environment Requirements
+A hardware hackathon requires a specialized environment that supports assembly, testing, collaboration, and provides easy access to power and specialized tools.
+
+## Workspace Needs
+* **Location and Layout:** Host the event in a large, open area, ideally adjacent to a functioning makerspace or fabrication lab. If this is not feasible, utilize engineering classrooms as they often have existing power and tables.
+* **Judging Accommodation:** If teams use the same tables for building and judging, ensure there are clear pathways and logical organization for judges. This setup also helps maintain general accessibility, and helps accommodate large or fragile projects that are difficult to move.
+* **Working space:** Provide ample tables and chairs. Ensure dedicated power access for soldering irons, 3D printers, and laptops. Utilize whiteboards, markers, and butcher paper for collaborative brainstorming and design.
+* **Common area:** Designate one common area (a classroom or lab) for all specialized tools and material checkout. This central hub is the ideal location for hardware checkout, kit pickup, and machined parts retrieval.
+* **Safety:** Clearly mark areas where hot tools or large machinery are in use. Have makerspace staff or trained volunteers supervise these zones. Display and share all safety protocols ahead of time.
+
+### Specialized Tool Stations
+Set up dedicated workstations for specialized activities (fabrication, debugging) to improve event logistics and aid cleanup. Ensure these stations are staffed by experienced volunteers.
+
+| Station | Essential Tools/Equipment | Tips |
+| :--- | :--- | :--- |
+| Fabrication | 3D printers, laser cutters, hand power tools | Some events delegate printing management to volunteers to allow participants to focus on their projects. |
+| Assembly/Wiring | Hot glue guns (with ample extra glue sticks), wire snippers, wire strippers, tweezers, electrical tape | Protect table surfaces with plywood or thick butcher paper. |
+| Testing/Debugging | Multimeters, USB programmers/cables | Offer video references ahead of time; ensure a mentor is stationed nearby. |
+| Specialized Electronics | Oscilloscopes, benchtop power supplies, soldering irons, logic analyzers | Consider hosting an asynchronous workshop for these tools before the event; ensure a mentor is stationed nearby. |
+
+## Tech Needs
+
+Reliable power and connectivity are non-negotiable foundations for any hardware event.
+
+### Power
+
+Ensure all venue outlets are functional. Provide sufficient surge-protected power strips at every station. Hardware projects often require separate power supplies for microcontrollers, laptops, chargers, and testing equipment.
+
+### Networking
+
+Secure robust, high-speed Wi-Fi and plan for peak usage (uploads, documentation, data streaming). Work with venue infrastructure to ensure the network allows IoT and other devices, as these are often blocked by standard university networks. Encourage hackers to pre-download software drivers and IDEs ahead of time to reduce network load during the event.

--- a/hardware-hackathon-guide/hardware-hackathon-timeline.md
+++ b/hardware-hackathon-guide/hardware-hackathon-timeline.md
@@ -1,0 +1,55 @@
+# Hardware Hackathon Organizing Timeline
+
+In addition to the timeline in our [organizer guide](../general-information/hackathon-timeline.md), here are a few extra tips when organizing a hardware hackathon:
+
+### 8–12 Months Out
+
+* Define a core theme
+* Reserve a large venue with ample power outlets, located near an accessible makerspace, lab, or machine shop
+* If the event has happened, collect hacker feedback on the components provided
+
+### 4–6 Months Out
+
+* Draft a comprehensive component list (technical and craft supplies) particularly known “good” or “easy to plug and play” hardware components, use hacker feedback from earlier
+* Estimate quantities based on expected number of teams.
+* Reserve access to specialized workshop areas
+ 
+### 3–4 Months Out
+
+* Order components and resources in bulk
+* Design a component testing plan for new and existing hardware inventory to ensure components work and work well/easily together
+* Test component(s) in existing hardware inventory to confirm functionality
+ 
+### 2–3 Months Out
+
+* Recruit mentors, volunteers, and judges from relevant technical and design fields. Aim for diversity
+* Plan the layout for the hardware lab checkout area and stations
+* Begin component testing as they arrive
+* Find and/or write additional documentation for newer hardware enthusiasts on the components in the lab
+* Plan workshops around registration questions asking for topics participants want to learn about
+ 
+### 1 Month Out
+* Finish testing all components
+* Finalize hardware lab assembly and the component checkout process
+* Test all power outlets and network connectivity in the venue space
+* Confirm material stock (e.g., 3D printer filament) in the makerspace
+ 
+### 1–2 Weeks Out
+
+* Send out volunteer and judge acceptances
+* Conduct training sessions
+ 
+### Week of the Event
+
+* Send out asynchronous resources to participants
+* Remind participants to download drivers/OS and to Bring Your Own Electronics/Hardware (BYOE/H)
+ 
+### During the Event
+
+* Remind hackers to keep spaces clean
+* Track broken components to inform the next restock
+
+### After the Event
+
+* Run end-of-event component and tool checklist for restock and budget planning
+

--- a/hardware-hackathon-guide/hardware-labs-and-additional-resources.md
+++ b/hardware-hackathon-guide/hardware-labs-and-additional-resources.md
@@ -1,0 +1,46 @@
+# Hardware Labs and Additional Resources
+
+Creating an optimal physical space is paramount for a successful hardware hackathon. Optimal spaces cultivate creativity and collaboration by providing technical components, construction materials, and tools. 
+
+
+### Common hardware lab components
+* Microcontrollers - Arduino UNO, Raspberry Pi, ESP32, LilyPad (for textile themes)
+* Passive Components - Breadboards, resistor kits, jumpers, standard LED kits, basic buttons/switches
+* Sensors/Actuators - Webcams/cameras, temperature/humidity sensors, distance sensors, basic motors/servos
+* Power - Battery packs, various cables/connectors/adapters, power strips
+
+### Vetting Components
+
+To maximize build time, prioritize an inventory of system-compatible hardware. This means selecting microcontrollers, sensors, and actuators that are pre-vetted to integrate with minimal configuration.
+* System Testing: Before the event, verify that your core components (e.g., an ESP32 and a specific sensor) communicate reliably
+* Standardized Connectors: Favor hardware that uses consistent plug-and-play standards (like QWIIC or Grove) to reduce time-consuming manual wiring and debugging
+* System Documentation: Provide code snippets or libraries that are verified for the specific hardware combinations in your lab
+
+### Expendable Hardware 
+USB cables, connector cables, jumper wires, breadboards, LEDs, RLC components, batteries, and similar consumables should be treated as expendables during a hackathon. While some will be able to be reused at a future event, be understanding if soldering, glue, or tape results in them needing to be replaced. 
+
+### Managing Your Hardware Inventory
+Your inventory (purchased, borrowed, or sponsored) and the MLH Hardware Lab (if present) should co-exist at the central checkout station.
+* Establish a process: If the event owns components, mark them clearly and establish a simple checkout process to ensure returns. Track borrowed tools using the respective lending institution's procedures.
+* MLH Lab: Utilize the MLH-provided inventory system and procedures for their components. Ensure volunteers are trained to distinguish between your event's inventory and MLH's to avoid confusion.
+
+### Additional Resources
+Have essential construction materials on hand for quickly building physical mock-ups, enclosures, and aesthetic finishing touches. If physical packaging or size constraints are critical, ensure you have a surplus of materials. Consider securing partnerships with local craft stores or budget for bulk consumables.
+
+#### Physical Supplies (examples)
+* cardboard
+* colored pencils and markers
+* scissors
+* rope
+* various glues
+* tape
+* fasteners
+
+#### Digital Supplies 
+Maintain a central repository (e.g., shared drive or page with links) to popular microcontroller IDEs, installers, and tutorials. Include product data sheets for components in your hardware lab.
+
+#### BYOE/D vs. Hacker Kits
+Hackers should always be encouraged to Bring Your Own Electronics/Devices (BYOE/D), as the lab may not have everything they need.
+
+**Basic Kits:** If budget permits, assemble or purchase beginner kits for novice hackers. A basic kit should contain: a microcontroller, a breadboard, basic resistors, jumper wires, and simple sensors/actuators. These kits often include tutorial booklets, making them an excellent inclusive resource. Arduino, Raspi, Grove, and many others have varying beginner or project-specific hardware kits to choose from.  
+

--- a/hardware-hackathon-guide/naming-and-framing-your-event.md
+++ b/hardware-hackathon-guide/naming-and-framing-your-event.md
@@ -1,0 +1,28 @@
+# Naming and Framing Your Event
+
+Choosing a name and theme (if desired) is your first opportunity to market your event and establish expectations. The terminology you use should align with the audience you want to attract and the goals you hope to achieve. Treat this information as a guide to help you find the best fit for your unique community.
+
+## Tips for choosing for your audience
+
+The language you use directly impacts who feels welcome and able to participate. Align your event title with the disciplines you most want to attract. Some participants might excel at code while others may thrive with 3D printing, soldering, or physical assembly. 
+
+| Audience Focus | Example Names | Events |
+| :--- | :--- | :--- |
+| Design/Art/Tech/ Textiles | Makeathon or Design Challenge | [DesignVerse](https://www.designverseucr.org/), [Fashion/Tech Hackathon](https://www.kent.edu/fashion/fashiontech-hackathon-0) |
+| Robotics/IoT/Electronics | Hardware Hackathon or Buildathon | [MakeUC](https://makeuc.io/), [MakeUofT](https://makeuoft.ca/) |
+| Sustainability/Civic Engagement | Design Challenge or SDG Buildathon | [CivicHacks](https://civic-hacks.com/), [Hack for LA](https://www.hackforla.org/) |
+
+## Tips for choosing your goals
+
+Your event's framing should clearly communicate its primary purpose, whether it's focused on education, innovation, advocacy, or something else.
+ 
+### Goal: Encouraging Learning and Skill Acquisition
+If the primary goal is hands-on education, emphasize skill growth and the opportunity to "see everyone grow and make." Highlight access to makerspaces and workshops. Provide asynchronous content (resource videos or handouts) ahead of time to efficiently address the hardware learning curve.
+ 
+### Goal: Driving Product Ideation and Innovation
+If the primary goal is to generate concrete, viable solutions for a partner or theme, emphasize the creation of market-ready prototypes. Host mandatory stakeholder workshops at the start to provide problem overviews and resources. Structure the event with critical design check-ins (best with stakeholders or a designated mentor) and a final time-constrained pitch and demonstration. Themes might focus on a specific function, or add constraints (i.e. must fit in a pocket). Products should aim to look and feel like they could exist in a commercial market. 
+
+### Goal: Promoting Advocacy and Awareness
+If the primary goal is to raise awareness for a civic or sustainable cause, marketing should highlight calls to action and achieving real-world impact. Partner with external organizations (e.g., non-profits) to provide real-world insights, frame the problems, and offer additional resources (mentoring, subject matter expertise).
+ 
+These are just some of the more common goals of hardware focused-events, you can choose your own goals not listed here!

--- a/hardware-hackathon-guide/pitfalls.md
+++ b/hardware-hackathon-guide/pitfalls.md
@@ -1,0 +1,43 @@
+# Pitfalls
+
+Hardware projects require precision under a tight time constraint. To help participants make optimal use of their limited time, communicate these common pitfalls and corresponding mitigation strategies.
+
+### Technical friction
+* Give hackers components vetted to work together as a system with minimal configuration
+
+### Scope creep and time management
+* Develop a thorough design plan early on, identifying the core components needed for a Minimum Viable Product (MVP) to get started quickly.
+
+Here's an example breakdown of how hackers might spend their time at a hackathon:
+* 10% Product Ideation (4.8 hours in a 24-hr hackathon)
+* 35% Product Development (8.4 hours in a 24-hr hackathon)
+* 30% Product Packaging (7.2 hours in a 24-hr hackathon)
+* 25% Product Documentation (6.0 hours in a 24-hr hackathon)
+
+### Component shortages
+* Bring Your Own Electronics/Hardware (BYOE/H): Bringing personal components reduces the likelihood of reliance on the main lab inventory. 
+
+> Organizer Note: Source additional parts or reserve ahead of time to minimize event shortages.
+
+### Soldering
+* Pre-solder headers on microcontrollers before the event if possible
+* Use hot glue for quick and durable prototyping
+
+### Hard to move projects
+* Build for portability and presentation:
+* Build the project on a movable surface (e.g., a tray or small cart).
+* Keep the project size manageable.
+* Design the project to be easy to disassemble and reassemble.
+* Take plenty of photos and videos showing the project working, especially for fragile or large assemblies, as backup for judging.
+
+### Long reset time
+* Document the process: Take frequent photos and videos showing the project working
+* Create a simple reset checklist for bringing the project back online after power loss, movement, or demo completion
+
+### Fabrication delays
+* Prototype early: The sooner your idea is finalized, the sooner the design can be measured, finalized, and sent to a 3D printer or fabricated (e.g., using laser cutters)
+* Around 30% of a team’s project time is recommended for physical packaging. That includes printing, fitting, etc. 
+
+### Robot pathing
+* Multiple paths: If your challenge(s) use a test floor on site (such as for robot pathing challenges), set up multiple test zones so that many teams can test during the event at once
+

--- a/hardware-hackathon-guide/prizes.md
+++ b/hardware-hackathon-guide/prizes.md
@@ -1,0 +1,26 @@
+# Prizes
+
+Prizes at a hardware hackathon should celebrate achievement, innovation, and learning. The most impactful prizes support the winning teams' continued interest in hardware development. Furthermore, projects that are market-ready can transform makers and hobbyists into entrepreneurs and inventors. 
+
+## Kits and Bundles
+Awarding curated hardware kits allows teams to immediately apply their newfound skills or iterate on their winning hack.
+* Advanced Kits: Offer kits centered around specific themes (e.g., Robotics Starter Kit, Smart Home Automation Kit, or advanced e-textiles for a wearables theme)
+* High-Value Components: Bundle high-end, specialized sensors, powerful microcontrollers (like Jetson Nano or higher-end Raspberry Pi models), or actuators that are often too expensive for students to purchase individually
+
+## Tools
+High-quality tools represent a significant investment for any maker and make excellent prizes
+* Professional-grade multimeters, oscilloscopes, or logic analyzers (if sponsored)
+* High-quality soldering stations, precision screwdriver sets, or ESD (Electrostatic Discharge) mat and wrist strap bundles.
+* Licenses for professional 3D modeling software or high-speed, compact 3D printers for personal use
+
+
+## Materials Costs
+Inspire future projects by removing financial barriers to continued making and providing access to fabrication resources.
+* Makerspace/Lab Credits: Offer vouchers redeemable at the university's makerspace or a local Fab Lab for material costs (filament, wood stock, metal stock, laser-cutting time).
+* Consumables Grant: Create a grant or endowment in the winning team's name to the campus lab for restocking popular, high-consumption materials (hot glue, craft supplies).
+* Scholarship/Free Access: Award a semester or year-long membership to a local, off-campus makerspace for continued access to large machining equipment (CNCs, lathes).
+
+## Additional Ideas
+Work with sponsors to create prize packages that reflect their industry and offer career-launching opportunities.
+* Industry-Specific Packages: An industrial sponsor could provide a small assembly of materials used in their manufacturing process, or a design firm could offer a year's access to their software suite.
+* Startup Funding Access: If partnering with a venture capital funder or incubator, offer the winning team an opportunity to present their project for future seed funding.

--- a/hardware-hackathon-guide/recruitment.md
+++ b/hardware-hackathon-guide/recruitment.md
@@ -1,0 +1,46 @@
+# Recruitment
+
+A successful hardware hackathon hinges on assembling a multidisciplinary community. You must intentionally market to and recruit individuals from beyond the typical computer science and software engineering pools. The core message across all roles must be: There is a place and a role for everyone here, as long as they are curious and ready to collaborate from the expert coder to the first-time maker.
+
+Check out our [marketing section](../general-information/marketing-your-event/README.md) if you want timelines and templates!
+
+## Participants
+
+The tangible nature of hardware projects creates a massive opportunity for diverse participation. Emphasize combining interests and appeal to seeing everyone grow and make. Alternatively, emphasize the event is learning-first and varying levels of experience are expected.
+
+| Recruitment Focus | Target Audience Examples | How to Market to Them |
+| :--- | :--- | :--- |
+| Across Disciplines | Engineers (ME, EE, Computer), Designers (Industrial, UX), Artists, Scientists, Humanities (Writers, Ethicists). | Explicitly state in promotional materials that all majors and backgrounds are welcome. Hardware requires a “whole product” approach, not just code |
+| Across talents | Students who may not self-identify as “hackers” but excel as crafters, designers, storytellers, etc. | Use gender-inclusive recruiting trends, such as emphasizing the event's outputs (creative, tangible things) and using photos of diverse teams and their creations. |
+| Wary individuals | Students concerned about the “hardware learning curve” | Mention the availability of resources (documentation, mentors, AI, experienced team members). Encouraging the use of AI as an assistant or extra team member may help. |
+
+### How to Form a Strong Hackathon Team
+Invite participants to form multidisciplinary teams to allow for efficient parallel creation. This approach is vital for hardware builds, where coding, fabrication, and design must happen simultaneously.
+ 
+A successful multidisciplinary team typically includes four core roles to maximize efficiency:
+* A programmer handles microcontrollers, firmware, and API integrations;
+* A fabricator handles wiring, 3D printing, laser cutting, and component assembly;
+* A designer handles UI/UX, structural planning, and materials/crafting use; and
+* A visionary handles storytelling, time management, and presentation (Project Management)
+Someone on the team should also be focused on quality assurance and debugging. 
+
+## Mentors 
+
+Mentors provide deep technical expertise and crucial thematic context. Recruit from sources that reflect the required disciplinary breadth:
+* **University Resources:** Faculty and alumni (especially ME, EE, Design), on-campus startups, and technical clubs (e.g., robotics).
+* **Partners & Sponsors:** Staff from makerspaces, fab labs, and engineers from sponsors who can provide technical assistance and specialized domain knowledge.
+* **Thematic Experts:** Recruit personnel from nonprofits or advocacy groups to speak to the event’s theme or tracks.
+Mentors should be comfortable balancing their expertise with leveraging AI to troubleshoot, demonstrating what today’s problem-solving looks like.
+
+## Judges
+
+Judges must be able to assess both the code and the physical execution of a prototype.
+* Recruit experts from incubators, startups, established local fab labs, and makerspaces.
+* Recruit Faculty in engineering, design, art, and specialized applied fields (e.g., faculty collaborating on wearable tech).
+* Recruit key technical or design personnel from top-tier sponsors. 
+
+## Volunteers
+Volunteers are the backbone of logistics and hospitality.
+* Recruit from potential participants who may be wary of attending their first (hardware) hackathon.
+* Source from local companies or organizations that expressed interest but declined full sponsorship this year.
+* Recruit current users of your campus makerspace or tech labs, as they are already familiar with the environment.

--- a/hardware-hackathon-guide/sponsors-and-partners.md
+++ b/hardware-hackathon-guide/sponsors-and-partners.md
@@ -1,0 +1,11 @@
+# Sponsors and Partners
+
+Hardware-focused events benefit immensely from local partnerships, often receiving crucial non-monetary contributions such as access to physical space, expensive equipment, and specialized staff.
+
+
+| Partner Type | Contribution |
+| :--- | :--- |
+| Makerspaces, Fab Labs, & University Labs | Venue space, large fabrication tools (3D printers, laser cutters, CNCs), safety supervision, and lab staff/mentors. |
+| Local Engineering Startups & National Labs | Advanced or specialized hardware (e.g., DSPs, specialized sensors), thematic mentorship, judging expertise, and recruitment opportunities. |
+| Nonprofits & Civic Organizations | Thematic focus and real-world context through problem statements and ethical personas (e.g., related to SDGs or accessibility challenges). |
+| Faculty & Department Collaborators | Access to classrooms, specific lab equipment, and recruitment of diverse mentors and judges (especially from Art, Design, and Bio-Engineering departments). |

--- a/hardware-hackathon-guide/why-hardware-hackathons.md
+++ b/hardware-hackathon-guide/why-hardware-hackathons.md
@@ -1,0 +1,22 @@
+# Why Hardware Hackathons
+
+## What are hardware hackathons?
+A hardware hackathon is a 24-36 hour prototyping or product-ideation event where participants design and build tangible products in service of a theme, or to solve a problem. It is a specialized hackathon focusing on creations that leverage microcontrollers, sensors, and actuators. Projects can include manufactured parts using machining, laser cutting, and 3D printing. The combination of hardware and fabrication makes prototypes come to life, creating potential future products or efficient or miniaturized designs. 
+ 
+Recent hardware hackathons MLH has partnered with:
+* HardHack
+* MakeCU
+* MakeMIT
+* MakeUofT
+
+_Let us know if you’re running a hardware hackathon, we’d love to partner with you and add your event to our list!_
+
+## Why host a hardware hackathon?
+
+Hardware hackathons share the core benefits of non-specialized events but break the status quo by bringing hardware and fabrication into the limelight. They thrive by focusing on sustainable technology, civic advocacy, and accessible living, often appealing to participants' call for community service.
+ 
+Participants "hack together" physical prototypes—tangible inventions that can be held and demonstrated. These projects span a wide creative background, ranging from assistive devices, smart home applications, and automated kitchen tools, to wearable electronics and hands-on learning tools. This process actualizes participants into becoming incredible inventors.
+
+## Your Goal As A Hardware Hackathon Organizer
+
+Ensure hackers can maximize their ideation and build time rather than get bogged down in debugging. Remember that hackers are juggling their time to do the following in 24 hours: ideation, dev, packaging (printing, fitting, etc.), and documentation (for submission). Ideation should take the least amount of time with hardware selection and software writing, and making enclosures taking the most amount of time. Minimize technical friction for your hackers by providing them with high-quality, easy-to-use hardware that your team has already vetted. 

--- a/hardware-hackathon-guide/workshops-and-learning-resources.md
+++ b/hardware-hackathon-guide/workshops-and-learning-resources.md
@@ -1,0 +1,35 @@
+# Workshops and Learning Resources
+
+Providing structured training and readily available resources boosts the confidence of first-time hackers and encourages teams. Evaluate the length of your event and organizer capacity to determine the optimal mix of resources.
+
+## Asynchronous Content
+
+Since many participants will prioritize building time during the event, providing accessible, asynchronous materials is critical. Async resources allow students to familiarize themselves with tools and concepts on their own schedule before the hackathon begins.
+
+| Resource Type | Content Focus | Suggested Delivery Method |
+| :--- | :--- | :--- |
+| Introductory Electronics | Basic component identification, breadboard wiring fundamentals, introduction to Arduino or Raspberry Pi. | Video Tutorials: Short, 5-10 minute videos demonstrating essential skills. |
+| Fabrication Basics | Safe use of a hot glue gun, principles of 3D printing (slicing, preparing a file), basic cardboard prototyping. | Guides (PDF): Simple, graphic-heavy guides for quick reference |
+| Coding for Hardware | Installing the IDE (Arduino or platform-specific), basic "Hello World" code for a microcontroller (e.g., blinking an LED), troubleshooting driver issues. | Async Resource Repository: A dedicated Google Drive or GitHub repository with code snippets and setup instructions |
+| Design Thinking | the "How Might We" method for defining a problem, inclusive problem solving | Video/Guide (PDF): Focusing on the Empathize and Define stages of the prototyping process |
+| Libraries | Links to specific libraries for components in the hardware lab | All in one document (PDF) or webpage with links |
+
+## Pre-Hackathon Workshops
+If hosting workshops before the event, focus on hands-on training for the primary components being used. For example:
+* Introduction to Microcontrollers: Hands-on workshop focusing on the core device provided (e.g., Arduino UNO). This covers basic wiring and the necessary initial code upload.
+* Starter Templates Worth Editing (With AI): Workshop focusing on where to find starter code and how to modify it with or without AI
+
+## Workshops During the Hackathon
+Limit the number of workshops during an event as they consume valuable building time. Schedule them earlier in the event when hackers are most likely to need guidance. These workshops should focus on core skills necessary for the weekend.
+
+#### Beginner Workshops Ideas:
+
+* Introduction to Microcontrollers (if not done before the event)
+* 3D Modeling Basics (crash course on free CAD software like Tinkercad)
+* Circuit Theory for Hackers (non-intimidating session on voltage, current, and multimeters)
+
+#### Additional Workshops Ideas:
+* Planning Your Hardware Project
+* Debugging Your Hardware Project
+* Aesthetics and Enclosure Design
+* Demoing Your Hack (pitch practice)


### PR DESCRIPTION
* Added hardware hackathon organizing guide
* Moved Hackathon themes to general guide
* Summary links updated for above

Minor test verification - confirm backlinks to general organizer guide in timeline, recruitment, and after the event pages function correctly. They worked for me but I'd like a second check.